### PR TITLE
Remove `emmet.syntaxProfiles` from Emmet section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@ This extension is applied to `.css`, `.pcss` and `.postcss` files. It also appli
 {
   "emmet.includeLanguages": {
     "postcss": "css"
-  },
-  "emmet.syntaxProfiles": {
-    "postcss": "css"
   }
 }
 ```


### PR DESCRIPTION
Note: If you used `emmet.syntaxProfiles` previously to map new file types, from VS Code 1.15 onwards you should use the setting `emmet.includeLanguages` instead. `emmet.syntaxProfiles` is meant for customizing the final output only.

https://code.visualstudio.com/docs/editor/emmet#_emmet-abbreviations-in-other-file-types