### PR TITLE
fix: repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "author": "Jonathan Neal <jonathantneal@hotmail.com>",
   "publisher": "csstools",
   "license": "CC0-1.0",
-  "repository": "csstools/postcss-language",
+  "repository": {
+      "type": "git",
+      "url": "https://github.com/csstools/postcss-language.git"
+  }
   "homepage": "https://github.com/csstools/postcss-language#readme",
   "bugs": "https://github.com/csstools/postcss-language/issues",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "repository": {
       "type": "git",
       "url": "https://github.com/csstools/postcss-language.git"
-  }
+  },
   "homepage": "https://github.com/csstools/postcss-language#readme",
   "bugs": "https://github.com/csstools/postcss-language/issues",
   "icon": "icon.png",


### PR DESCRIPTION
Hi,

I'm trying to [add postcss-language to VSX](https://github.com/open-vsx/publish-extensions/pull/58) but it fails due to an invalid `repository` value in `package.json`, this should fix it.

Thanks