### PR TITLE
Contribute `source.postcss` and `source.css.postcss` scopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,20 @@
         "language": "postcss"
       },
       {
+        "scopeName": "source.postcss",
+        "injectTo": [
+          "source.css"
+        ],
+        "path": "./syntaxes/source.postcss.tmLanguage.json"
+      },
+      {
+        "scopeName": "source.css.postcss",
+        "injectTo": [
+          "source.css"
+        ],
+        "path": "./syntaxes/source.css.postcss.tmLanguage.json"
+      },
+      {
         "scopeName": "text.html.markdown.css",
         "path": "./syntaxes/text.html.markdown.css.tmLanguage.json",
         "injectTo": [

--- a/syntaxes/source.css.postcss.tmLanguage.json
+++ b/syntaxes/source.css.postcss.tmLanguage.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "injectionSelector": "source.css",
+  "patterns": [
+    {
+      "include": "source.css"
+    }
+  ],
+  "scopeName": "source.css.postcss"
+}

--- a/syntaxes/source.postcss.tmLanguage.json
+++ b/syntaxes/source.postcss.tmLanguage.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "injectionSelector": "source.css",
+  "patterns": [
+    {
+      "include": "source.css"
+    }
+  ],
+  "scopeName": "source.postcss"
+}


### PR DESCRIPTION
This PR aims to provide `source.postcss` and `source.css.postcss` scopes for other extensions and close #6, #8.

Currently this would only benefit Volar (johnsoncodehk/volar#191) as Vetur (vuejs/vetur@d96067d) and Svelte (sveltejs/language-tools#1044) have chosen to bundle their own grammars.